### PR TITLE
(12.12) feature: [be] 엔티티 생성. 필요 시 users 엔티티 추가 필요 (12.11) feature: [be] livelecture security 기본 코드 작성 및 mysql 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.0'
-	id 'io.spring.dependency-management' version '1.1.6'
+	id 'org.springframework.boot' version '3.2.2'
+	id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.yoganavi'
@@ -13,16 +13,54 @@ java {
 	}
 }
 
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
 repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2023.0.0")
+}
+
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	implementation 'org.apache.commons:commons-lang3'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/src/main/java/com/yoganavi/live_lecture/common/config/SecurityConfig.java
+++ b/src/main/java/com/yoganavi/live_lecture/common/config/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.yoganavi.live_lecture.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                    // 필요한 엔드포인트 권한 설정
+//                .requestMatchers("").hasRole("admin")
+//                .requestMatchers("").authenticated()
+//                .requestMatchers("").authenticated()
+                    .anyRequest().permitAll()
+            );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/yoganavi/live_lecture/common/entity/LectureSchedule.java
+++ b/src/main/java/com/yoganavi/live_lecture/common/entity/LectureSchedule.java
@@ -1,0 +1,83 @@
+package com.yoganavi.live_lecture.common.entity;
+
+import com.yoganavi.live_lecture.common.enums.LectureStatus;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.DayOfWeek;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 개별 강의 일정 저장 특정 날짜와 시간에 진행되는 각각의 강의 관리
+ */
+@Entity
+@Getter
+@Setter
+@Table(name = "lecture_schedules")
+public class LectureSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long scheduleId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "live_id", nullable = false)
+    private LiveLectures lecture;
+
+    @Column(nullable = false)
+    private LocalDate lectureDate; // 강의 날짜
+
+    @Column(nullable = false)
+    private LocalDateTime startTime; // 강의 시작 시간
+
+    @Column(nullable = false)
+    private LocalDateTime endTime;   // 강의 종료 시간
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek dayOfWeek;    // 강의 요일
+
+    /**
+     * 현재 강의가 진행 중인지
+     *
+     * @return 현재 시간이 강의 시간 내인 경우 true
+     */
+    public boolean isActive() {
+        LocalDateTime now = LocalDateTime.now();
+        return !now.isBefore(startTime) && !now.isAfter(endTime);
+    }
+
+    /**
+     * 강의가 시작 전인지
+     *
+     * @return 현재 시간이 강의 시작 시간 이전인 경우 true
+     */
+    public boolean isUpcoming() {
+        return LocalDateTime.now().isBefore(startTime);
+    }
+
+    /**
+     * 강의가 종료되었는지
+     *
+     * @return 현재 시간이 강의 종료 시간 이후인 경우 true
+     */
+    public boolean isCompleted() {
+        return LocalDateTime.now().isAfter(endTime);
+    }
+
+    /**
+     * 강의 상태 확인
+     *
+     * @return 강의 현재 상태
+     */
+    public LectureStatus getStatus() {
+        if (isUpcoming()) {
+            return LectureStatus.UPCOMING;  // 들어야 함
+        } else if (isActive()) {
+            return LectureStatus.ACTIVE;    // 강의 듣는중
+        } else {
+            return LectureStatus.COMPLETED; // 수강 완료
+        }
+    }
+}

--- a/src/main/java/com/yoganavi/live_lecture/common/entity/LiveLectures.java
+++ b/src/main/java/com/yoganavi/live_lecture/common/entity/LiveLectures.java
@@ -1,0 +1,44 @@
+package com.yoganavi.live_lecture.common.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 강의 메타데이터를 저장 강의의 기본 정보, 개별 강의 일정(LectureSchedule) 관리
+ */
+@Entity
+@Getter
+@Setter
+@Table(name = "live_lectures")
+public class LiveLectures {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long liveId;    // 강의 고유 식별자
+
+    @Column(length = 30, nullable = false)
+    private String liveTitle;   // 강의 제목
+
+    @Column(length = 300)
+    private String liveContent; // 강의 설명
+
+    @Column(nullable = false)
+    private Integer maxLiveNum; // 최대 수강 인원
+
+    @Column(nullable = false)
+    private LocalDateTime regDate;  // 강의 등록 일시
+
+    @Column(nullable = false)
+    private Long userId;    // 강사 ID
+
+    @Column(nullable = false)
+    private Boolean isOnAir = false;    // 강의 진행 상태 (true: 진행 중, false: 종료)
+
+    @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<LectureSchedule> schedules = new ArrayList<>();
+
+}

--- a/src/main/java/com/yoganavi/live_lecture/common/entity/MyLiveLecture.java
+++ b/src/main/java/com/yoganavi/live_lecture/common/entity/MyLiveLecture.java
@@ -1,0 +1,50 @@
+package com.yoganavi.live_lecture.common.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 학생별 수강 강의 정보 저장 각 강의 일정(LectureSchedule)에 대한 수강 상태 관리
+ */
+@Entity
+@Getter
+@Setter
+@Table(name = "my_live_lectures",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"userId", "schedule_id"})
+    })
+public class MyLiveLecture {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long myListId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id", nullable = false)
+    private LectureSchedule lectureSchedule;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private boolean completed = false;
+
+    /**
+     * 현재 수강 가능한 강의인지
+     *
+     * @return 강의가 끝나지 않음, 수강 완료하지 않은 경우 true
+     */
+    public boolean isAvailable() {
+        return !completed && !lectureSchedule.isCompleted();
+    }
+
+    /**
+     * 현재 진행중인 강의인지
+     *
+     * @return 수강 완료하지 않음, 현재 강의가 진행중인 경우 true
+     */
+    public boolean isInProgress() {
+        return !completed && lectureSchedule.isActive();
+    }
+}

--- a/src/main/java/com/yoganavi/live_lecture/common/enums/LectureStatus.java
+++ b/src/main/java/com/yoganavi/live_lecture/common/enums/LectureStatus.java
@@ -1,0 +1,17 @@
+package com.yoganavi.live_lecture.common.enums;
+
+public enum LectureStatus {
+    UPCOMING("예정된 강의"),
+    ACTIVE("진행 중"),
+    COMPLETED("종료됨");
+
+    private final String description;
+
+    LectureStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/yoganavi/live_lecture/common/filter/UserAuthenticationFilter.java
+++ b/src/main/java/com/yoganavi/live_lecture/common/filter/UserAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.yoganavi.live_lecture.common.filter;
+
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class UserAuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        String userId = request.getHeader("X-Member-Id");
+        String role = request.getHeader("X-ROLE");
+
+        if (userId != null && role != null) {
+            List<GrantedAuthority> authorities = Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_" + role)
+            );
+
+            Authentication auth = new UsernamePasswordAuthenticationToken(
+                userId,
+                null,
+                authorities
+            );
+
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/yoganavi/live_lecture/controller/HomeController.java
+++ b/src/main/java/com/yoganavi/live_lecture/controller/HomeController.java
@@ -1,0 +1,95 @@
+package com.yoganavi.live_lecture.controller;
+
+import com.yoganavi.live_lecture.dto.HomeResponseDto;
+import com.yoganavi.live_lecture.dto.SetIsOnAirDto;
+import com.yoganavi.live_lecture.service.HomeService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/live-lecture/home")
+public class HomeController {
+
+    private final HomeService homeService;
+
+    /**
+     * 홈 페이지 요청 처리
+     *
+     * @return 홈 페이지에 대한 응답
+     */
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> getHomeData(
+        @RequestHeader("X-User-Id") Long userId,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "30") int size) {
+
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            List<HomeResponseDto> homeData = homeService.getHomeData(userId, page, size);
+
+            response.put("message", "내 화상 강의 할 일 조회 성공");
+            response.put("data", homeData);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (Exception e) {
+
+            response.put("message", "내 화상강의 할 일 조회 실패");
+            response.put("data", new Object[]{});
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        }
+    }
+
+    /**
+     * 시그널링 서버 상태 업데이트
+     *
+     * @param setIsOnAirDto 시그널링 서버 상태 담은 dto
+     * @return 업데이트 성공 여부
+     */
+    @PutMapping("/update")
+    public ResponseEntity<Map<String, Object>> updateLiveStatus(
+        @RequestBody SetIsOnAirDto setIsOnAirDto) {
+        log.info("라이브 상태 업데이트 요청: 강의 ID {}, 상태 {}", setIsOnAirDto.getLiveId(),
+            setIsOnAirDto.getOnAir());
+        Map<String, Object> response = new HashMap<>();
+        try {
+            boolean result = homeService.updateLiveState(setIsOnAirDto.getLiveId(),
+                setIsOnAirDto.getOnAir());
+            if (result) {
+                log.info("라이브 상태 업데이트 성공: 강의 ID {}", setIsOnAirDto.getLiveId());
+                response.put("message", "success");
+                response.put("data", new Object[]{});
+                return ResponseEntity.status(HttpStatus.OK).body(response);
+            } else {
+                log.warn("라이브 상태 업데이트 실패: 강의 ID {}", setIsOnAirDto.getLiveId());
+                response.put("message", "fail");
+                response.put("data", new Object[]{});
+                return ResponseEntity.status(HttpStatus.NOT_MODIFIED).body(response);
+            }
+        } catch (NullPointerException e) {
+            log.error("라이브 상태 업데이트 실패 (강의를 찾지 못함): 강의 ID {}", setIsOnAirDto.getLiveId());
+            response.put("message", "fail");
+            response.put("data", new Object[]{});
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+        } catch (Exception e) {
+            log.error("라이브 상태 업데이트 중 오류 발생: 강의 ID {}, 오류 메시지: {}", setIsOnAirDto.getLiveId(),
+                e.getMessage());
+            response.put("message", "fail");
+            response.put("data", new Object[]{});
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        }
+    }
+}

--- a/src/main/java/com/yoganavi/live_lecture/dto/HomeResponseDto.java
+++ b/src/main/java/com/yoganavi/live_lecture/dto/HomeResponseDto.java
@@ -1,0 +1,34 @@
+package com.yoganavi.live_lecture.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 홈 페이지 응답 DTO
+ */
+@Getter
+@Setter
+public class HomeResponseDto {
+
+    private Long liveId;
+    private String nickname;
+    private String profileImageUrl;
+    private String profileImageUrlSmall;
+    private String liveTitle;
+    private String liveContent;
+    private Long startTime;
+    private Long endTime;
+    private Long lectureDate;
+    private String lectureDay;
+    private Integer maxLiveNum;
+    private Boolean teacher;
+    private Boolean isOnAir;
+
+    public boolean isTeacher() {
+        return teacher;
+    }
+
+    public void setTeacher(boolean teacher) {
+        this.teacher = teacher;
+    }
+}

--- a/src/main/java/com/yoganavi/live_lecture/dto/SetIsOnAirDto.java
+++ b/src/main/java/com/yoganavi/live_lecture/dto/SetIsOnAirDto.java
@@ -1,0 +1,13 @@
+package com.yoganavi.live_lecture.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SetIsOnAirDto {
+
+    private long liveId;
+    private Boolean onAir;
+
+}

--- a/src/main/java/com/yoganavi/live_lecture/repository/LectureScheduleRepository.java
+++ b/src/main/java/com/yoganavi/live_lecture/repository/LectureScheduleRepository.java
@@ -1,0 +1,10 @@
+package com.yoganavi.live_lecture.repository;
+
+import com.yoganavi.live_lecture.common.entity.LectureSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LectureScheduleRepository extends JpaRepository<LectureSchedule, Integer> {
+
+}

--- a/src/main/java/com/yoganavi/live_lecture/repository/LiveLecturesRepository.java
+++ b/src/main/java/com/yoganavi/live_lecture/repository/LiveLecturesRepository.java
@@ -1,0 +1,11 @@
+package com.yoganavi.live_lecture.repository;
+
+import com.yoganavi.live_lecture.common.entity.LiveLectures;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LiveLecturesRepository extends JpaRepository<LiveLectures, Long> {
+
+
+}

--- a/src/main/java/com/yoganavi/live_lecture/repository/MyLiveLectureRepository.java
+++ b/src/main/java/com/yoganavi/live_lecture/repository/MyLiveLectureRepository.java
@@ -1,0 +1,10 @@
+package com.yoganavi.live_lecture.repository;
+
+import com.yoganavi.live_lecture.common.entity.MyLiveLecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MyLiveLectureRepository extends JpaRepository<MyLiveLecture, Integer> {
+
+}

--- a/src/main/java/com/yoganavi/live_lecture/service/HomeService.java
+++ b/src/main/java/com/yoganavi/live_lecture/service/HomeService.java
@@ -1,0 +1,11 @@
+package com.yoganavi.live_lecture.service;
+
+import com.yoganavi.live_lecture.dto.HomeResponseDto;
+import java.util.List;
+
+public interface HomeService {
+
+    List<HomeResponseDto> getHomeData(Long userId, int page, int size);
+
+    boolean updateLiveState(Long liveId, Boolean isOnAir);
+}

--- a/src/main/java/com/yoganavi/live_lecture/service/HomeServiceImpl.java
+++ b/src/main/java/com/yoganavi/live_lecture/service/HomeServiceImpl.java
@@ -1,0 +1,25 @@
+package com.yoganavi.live_lecture.service;
+
+import com.yoganavi.live_lecture.dto.HomeResponseDto;
+import com.yoganavi.live_lecture.repository.LiveLecturesRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HomeServiceImpl implements HomeService {
+
+    private final LiveLecturesRepository liveLecturesRepository;
+
+    @Override
+    public List<HomeResponseDto> getHomeData(Long userId, int page, int size) {
+        return null;
+    }
+
+
+    @Override
+    public boolean updateLiveState(Long liveId, Boolean isOnAir) {
+        return false;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,54 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/live_lecture?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      idle-timeout: 300000
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 2
+
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+  instance:
+    prefer-ip-address: true
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        permittedNumberOfCallsInHalfOpenState: 3
+        waitDurationInOpenState: 5s
+        failureRateThreshold: 50
+  timelimiter:
+    configs:
+      default:
+        timeoutDuration: 3s

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,43 @@
+spring:
+  # datasource 설정
+  # jpa 설정
+
+  data:
+    redis:
+      host: redis-live-lecture
+      port: 6379
+      lettuce:
+        pool:
+          max-active: 16
+          max-idle: 16
+          min-idle: 4
+
+  rabbitmq:
+    host: moeum-rabbitmq
+    port: 5672
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://eureka-server:8761/eureka/
+  instance:
+    prefer-ip-address: true
+    lease-renewal-interval-in-seconds: 30
+    lease-expiration-duration-in-seconds: 90
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        slidingWindowSize: 100
+        minimumNumberOfCalls: 50
+        waitDurationInOpenState: 60s
+        failureRateThreshold: 50
+
+logging:
+  file:
+    name: /var/log/live-lecture/live-lecture.log
+  logback:
+    rollingpolicy:
+      max-file-size: 10MB
+      max-history: 30

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=live-lecture-service

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,32 @@
+spring:
+  application:
+    name: live-lecture-service
+  profiles:
+    active: local
+  config:
+    import: classpath:application-secret.yml
+
+server:
+  port: 8082
+
+management:
+  endpoint:
+    health:
+      show-details: always
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics,prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name}
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      sla:
+        http.server.requests: 1ms,5ms,10ms,50ms,100ms,200ms,500ms,1s,5s
+
+logging:
+  level:
+    root: INFO
+    com.yourpackage.livelecture: DEBUG


### PR DESCRIPTION
**1. LiveLectures (강의 메타데이터 엔티티)**
- 강의의 기본 정보를 관리하는 메인 엔티티
- 실제 강의 일정과 분리하여 관리 -> 강의 정보 재사용 용이
- @OneToMany로 LectureSchedule과 연관관계를 맺어 여러 회차의 강의 스케줄 관리 가능
- 내가 생각하는 장점
  - 강의 기본 정보 수정이 용이 (모든 스케줄에 동일하게 적용)
  - 동일 강의의 여러 시간대 운영 가능


**2. LectureSchedule (강의 일정 엔티티)**
- 개별 강의 회차의 일정을 관리
- 편의 메서드(isActive, isCompleted 등)로 상태 확인 로직 간편화
- 내가 생각하는 장점:
  - 각 강의 회차별 독립적인 시간 관리 가능
  - 스케줄 기반 검색/필터링 최적화
  - 상태 확인 로직 중복 제거


**3. MyLiveLecture (수강 정보 엔티티)**
- LectureSchedule과 직접 연관관계
- 플래그로 상태 관리
- 유니크 제약조건으로 중복 수강 방지
- 내가 생각하는 장점:
  - 데이터 중복 최소화
  - 상태 관리 복잡도 감소
  - 실제 강의 일정과 수강 정보의 정확한 매칭